### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,5 +7,12 @@
 | Name             | Github           |
 | ---------------- | ---------------- |
 | Philipp Schlarb | pSchlarb |
-| Robin Klemens | udosson |
 | Wade Barnes | WadeBarnes |
+
+## Emeritus Maintainers
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| Name             | Github           |
+| ---------------- | ---------------- |
+| Robin Klemens | udosson |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>